### PR TITLE
Fix blocking call to register_quirks in event loop

### DIFF
--- a/custom_components/aqara_advanced_lighting/__init__.py
+++ b/custom_components/aqara_advanced_lighting/__init__.py
@@ -135,7 +135,7 @@ async def async_setup(hass: HomeAssistant, config: dict) -> bool:
     # pick up the newly registered quirk definitions.
     from .quirks import register_quirks
 
-    register_quirks()
+    await hass.async_add_executor_job(register_quirks)
 
     # Initialize domain data storage with multi-instance support
     hass.data.setdefault(DOMAIN, {


### PR DESCRIPTION
Run register_quirks() via async_add_executor_job to move the heavy zigpy import (which triggers scandir, file reads, and SSL cert loading) off the event loop.